### PR TITLE
Fix post deletion query

### DIFF
--- a/Repository/Query/PostQuery.cs
+++ b/Repository/Query/PostQuery.cs
@@ -24,7 +24,7 @@ public static class PostQuery
                                             Description = @Description 
                                             WHERE Id = @Id;";
 
-    public const string DeletePostQuery = @"Update Posts Set IsDeleted=1";
+    public const string DeletePostQuery = @"UPDATE Posts SET IsDeleted = 1 WHERE Id = @Id;";
 
     public const string PostTypeIdQuery = @"SELECT Id FROM PostTypes WHERE Prefix=@Prefix";
 }


### PR DESCRIPTION
## Summary
- fix `DeletePostQuery` so that deleting a post only affects the selected post

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6848074afccc8330881e1deb1dda0fa9